### PR TITLE
Update download and links page to reflect github move

### DIFF
--- a/download.shtml
+++ b/download.shtml
@@ -110,7 +110,7 @@ Oolite 1.76.1 &nbsp;(23&nbsp;MiB)<br>
 <h1 style="margin-top:50px">Test Release configuration</h1>
 <div class="txt" style="width:70%; margin-top:20px">
 Oolite releases (version 1.77 or later) are delivered using Deployment Release configuration to ensure maximum performance.
-Patch programs for Test Release configuration are available from <a href="http://developer.berlios.de/project/showfiles.php?group_id=3577">BerliOS</a>.<br>
+Patch programs for Test Release configuration are available from <a href="https://github.com/OoliteProject/oolite/releases">GitHub</a>.<br>
 <br>
 Test Release configuration is intended for testers, maintainers, OXP developers and in general for whoever has an interest in having Oolite configured with the following debugging features (at the expense of performance):<br>
 <ul style="margin-left:30px">
@@ -128,7 +128,7 @@ Test Release configuration is intended for testers, maintainers, OXP developers 
 </div>
 
 <h1 style="margin-top:50px">Source Code and Updates</h1>
-<div class="txt" style="width:70%; margin-top:20px">Source code for all platforms is available from <a href="http://developer.berlios.de/project/showfiles.php?group_id=3577">BerliOS</a>. New test releases are announced on the <a href="http://www.aegidian.org/bb/">forum</a>.</div>
+<div class="txt" style="width:70%; margin-top:20px">Source code for all platforms is available from <a href="https://github.com/OoliteProject/oolite">GitHub</a>. New test releases are announced on the <a href="http://www.aegidian.org/bb/">forum</a>.</div>
   
    <h1 style="margin-top:50px">Add-ons</h1>
 <div class="txt" style="width:70%; margin-top:20px">There are numerous expansion packs and other add-ons for Oolite. Don’t forget to look at the <a href="http://www.oolite.org/links">Links</a> page!</div>

--- a/links.shtml
+++ b/links.shtml
@@ -54,8 +54,8 @@ menu('links')
 
 <h1 id="development" style="margin-top:50px">Development</h1>
 <div class="txt" style="width:70%; margin-top:20px">
-<a href="http://developer.berlios.de/projects/oolite-linux/">Project Page</a> &mdash; the centre of Oolite development. Source code, test releases and bug tracking can be found here.<br />
-<a href="http://developer.berlios.de/bugs/?group_id=3577">Bug Tracker</a> &mdash; please report bugs here.
+<a href="https://github.com/OoliteProject/oolite">Project Page</a> &mdash; the centre of Oolite development. Source code, test releases and bug tracking can be found here.<br />
+<a href="https://github.com/OoliteProject/oolite/issues">Bug Tracker</a> &mdash; please report bugs here.
 </div>
 
 


### PR DESCRIPTION
Decided to check in on one of my favorite open source games and was a little concerned- well, actually you scared the crap out of me -to see that the berlios links to the code were broken. Berlios itself is looking kind of broken these days for that matter. So thought I'd do an update of the links to the new github repo.

I really can't remember what the file list looked like on berlios so I made the first link on the downloads page go to the release list. Hope that's sufficient.
